### PR TITLE
chore: bump nostr-rs-relay to latest master (NIP-91, bug fixes)

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,10 +1,14 @@
 id: nostr
 title: "Nostr RS Relay"
-version: 0.9.0
+version: 0.9.1
 release-notes: |
-  * Upstream code update
-  * Code cleanup and fixes
-  * Update bundling process to use Deno emit module
+  * Bump nostr-rs-relay to latest master (17 commits ahead of 0.9.0)
+  * NIP-91 support: tag querying for SQLite and PostgreSQL
+  * Fix disconnect handling and subscription send errors
+  * Fix deterministic ordering for AND tag operations
+  * Fix auth event confirmation and NIP-05 verifier
+  * Two rounds of dependency upgrades
+  * Clippy and rustfmt cleanup
 license: MIT
 wrapper-repo: "https://github.com/Start9Labs/nostr-rs-relay-startos"
 upstream-repo: "https://sr.ht/~gheartsfield/nostr-rs-relay/"


### PR DESCRIPTION
## Summary

- Bumps the `nostr-rs-relay` submodule to latest master (17 commits ahead of 0.9.0 tag, commit `64cfcaf`)
- Version bumped to `0.9.1`

## Key upstream changes

- **NIP-91 support**: tag querying for both SQLite and PostgreSQL backends
- **Bug fixes**: disconnect handling for subscription send errors, deterministic ordering for AND tag operations, auth event confirmation, NIP-05 verifier
- **Maintenance**: two rounds of dependency upgrades, clippy/rustfmt cleanup
- **Build**: added `CARGO_LOG` build arg, awk required for jemalloc build

## Full commit log (since 0.9.0)

- `64cfcaf` fix: disconnect for subscription send errors
- `1d2bd26` fix: handle send errors in main select loop
- `3f4a4fc` fix: use deterministic order for AND tag ops
- `d320041` build: Add CARGO_LOG build arg
- `7645ac1` feat(NIP-91): sqlite impl for &tag
- `04b5051` feat(NIP-91): tag and query (postgres)
- `2022bd6` build: awk required for jemalloc build
- `f09a2b8` improvement: upgrade dependencies
- `184adf1` fix: flake build
- `30d0712` fix: confirm auth event
- `d72af96` refactor: rustfmt
- `b4234ea` refactor: clippy suggestions
- `d73cde2` fix: only send events to the nip05 verifier if grpc permits
- `afbd755` improvement: update dependencies
- `a6b4862` fix: sqlite schema comment
- `d71f5cb` docs: remove reference to defunct anigma channel
- `1ed8cc0` docs: point github CI badge to main repo