### PR TITLE
chore: bump start-sdk to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "nostr-rs-relay-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1"
+        "@start9labs/start-sdk": "1.5.2"
       },
       "devDependencies": {
         "@types/node": "^20.19.27",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -342,7 +342,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1"
+    "@start9labs/start-sdk": "1.5.2"
   },
   "devDependencies": {
     "@types/node": "^20.19.27",

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_0_9_0_7 } from './v0.9.0.7'
+import { v_0_9_0_8 } from './v0.9.0.8'
 
 export const versionGraph = VersionGraph.of({
-  current: v_0_9_0_7,
+  current: v_0_9_0_8,
   other: [],
 })

--- a/startos/versions/v0.9.0.8.ts
+++ b/startos/versions/v0.9.0.8.ts
@@ -4,14 +4,14 @@ import { readdir, readFile, rm } from 'fs/promises'
 import { join } from 'path'
 import { configToml } from '../fileModels/config.toml'
 
-export const v_0_9_0_7 = VersionInfo.of({
-  version: '0.9.0:7',
+export const v_0_9_0_8 = VersionInfo.of({
+  version: '0.9.0:8',
   releaseNotes: {
-    en_US: 'Internal updates (start-sdk 1.5.0)',
-    es_ES: 'Actualizaciones internas (start-sdk 1.5.0)',
-    de_DE: 'Interne Aktualisierungen (start-sdk 1.5.0)',
-    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.5.0)',
-    fr_FR: 'Mises à jour internes (start-sdk 1.5.0)',
+    en_US: 'Internal updates (start-sdk 1.5.2)',
+    es_ES: 'Actualizaciones internas (start-sdk 1.5.2)',
+    de_DE: 'Interne Aktualisierungen (start-sdk 1.5.2)',
+    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.5.2)',
+    fr_FR: 'Mises à jour internes (start-sdk 1.5.2)',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps `@start9labs/start-sdk` 1.5.0 → 1.5.2 and the StartOS revision to `0.9.0:8`.
- Upstream `nostr-rs-relay` remains at 0.9.0 — still the latest sourcehut release (Sep 2024).

## SDK changelog (1.5.0 → 1.5.2)

- **1.5.2** — fixes `Backups.withPgDump` / `withMysqlDump` (they were silently dropping writes through the FUSE bind mount). Not used in this package, so no code change needed.
- **1.5.1** — fixes `GetActionInputType` for `ActionInfo`-based task inference; loosens `BindOptions.addSsl` to `Partial<...>` for non-SSL protocols. Nothing this package consumes.

## Test plan

- [x] `make` builds clean for `x86_64` and `aarch64` against SDK 1.5.2.